### PR TITLE
Honor intention of suppressExitCode option

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ async function init () {
 
 function runNewman (options) {
   newman.run(options).on('done', (err, summary) => {
-    if (err || summary.run.failures.length) {
+    if (!options.suppressExitCode && (err || summary.run.failures.length)) {
       core.setFailed('Newman run failed!' + (err || ''))
     }
   })


### PR DESCRIPTION
More than simply an option that's passed to Newman, the action itself should honor this intention.

In my own case, the newman run generated application logs that I needed to inspect to determine how to alter the build in question.  If the exit code is not suppressed, the logs aren't written anywhere that can be read, and the action dies right there-- (since, presumably, there are run failures).

This patch should allow that to continue on.  In this "test of one," we have since fixed the issue, disabled this option, and the action still works as it should.

Thanks for this repository, it was of importance to us!  Hopefully this is helpful as well.