### PR TITLE
check environment exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ async function init () {
       options.collection = `${apiBase}/collections/${options.collection}?apikey=${options.apiKey}`
     }
 
-    if (options.environment.match(idRegex)) {
+    if (options.environment && options.environment.match(idRegex)) {
       if (!options.apiKey) {
         core.setFailed('No Postman API key provided for environment retrieval.')
       }


### PR DESCRIPTION
## Overview

`environment` is not required parameter but an error occurred if it is not set.

https://github.com/matt-ball/newman-action/blob/573e42a0a75f676336800aa40d7b63b2acdc4ff3/index.js#L51

```shell
Error: Cannot read property 'match' of null
```

## Solution

I added `environment` check logic.