### PR TITLE
Add clarifying details on using the Postman API

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ If you're collection and/or environment is sitting at a URL accessible to your G
 ```
 
 ### Via Postman API
-The latest version of your collection and/or environment is available through [Postman's API](https://docs.api.getpostman.com/?version=latest). The API docs contain endpoints that will allow you to retrieve the required IDs. Passing these IDs along with your Postman API key will run Newman in this method. See [Creating and using secrets](https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository) for how to add your Postman API to GitHub securely.
+The latest version of your collection and/or environment is available through [Postman's API](https://docs.api.getpostman.com/?version=latest). The API docs contain endpoints that will allow you to retrieve the required UIDs. Note the distinction between UID and ID. The Postman API will return responses with `id` and `uid` fields. You'll want the `uid` value, not the `id` value.
+
+Passing these UIDs along with your Postman API key will run Newman in this method. See [Creating and using secrets](https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository) for how to add your Postman API to GitHub securely.
 
 ```
 - uses: actions/checkout@master


### PR DESCRIPTION
The Postman API is a bit unconventional in that it returns `id` and `uid` keys on collections and environments. Let's update the README to explain this distinction and highlight that the `uid` value is what is needed when using the API approach to getting collection and environment details.